### PR TITLE
Apply syntax highlighting to githubs `exclude` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "categories": [
         "Programming Languages"
     ],
+	"keywords": [
+		"exclude"
+	],
     "galleryBanner": {
       "color": "#569cd6",
       "theme": "dark"
@@ -32,6 +35,10 @@
                     "gitignore",
                     ".gitignore"
                 ],
+				"filenamePatterns": [
+					"**/.git/info/exclude"
+				],
+				"firstLine": "^# git ls-files --others --exclude-from=\\.git/info/exclude$",
                 "configuration": "./language-configuration.json"
             }
         ],


### PR DESCRIPTION
The `exclude` file found under `../.git/info/exclude` (when cloning a repo) is functionality the same as `.gitignore` and can be safely highlighted in the same way

example:
![image](https://github.com/dunstontc/vscode-gitignore-syntax/assets/33529441/0f00f7b3-6f04-4f58-b981-2536b2cf2ebf)
